### PR TITLE
Change solidity version 0.4.17 < 0.6.0

### DIFF
--- a/contract.sol
+++ b/contract.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.5.0 < 0.6.0;
+pragma solidity >=0.4.17 < 0.6.0;
 contract TokenReward {
     
     struct Member {


### PR DESCRIPTION
Following ERC20 Token standard there are specifications that use syntax from Solidity 0.4.17 (or above).